### PR TITLE
added skipping of lib/ and swig/ if sources list is empty

### DIFF
--- a/gr-utils/python/modtool/gr-newmod/lib/CMakeLists.txt
+++ b/gr-utils/python/modtool/gr-newmod/lib/CMakeLists.txt
@@ -28,6 +28,12 @@ link_directories(${Boost_LIBRARY_DIRS})
 list(APPEND howto_sources
 )
 
+set(howto_sources "${howto_sources}" PARENT_SCOPE)
+if(NOT howto_sources)
+	MESSAGE(STATUS "no C++ sources... skipping lib/")
+	return()		
+endif(NOT howto_sources)
+
 add_library(gnuradio-howto SHARED ${howto_sources})
 target_link_libraries(gnuradio-howto ${Boost_LIBRARIES} ${GNURADIO_ALL_LIBRARIES})
 set_target_properties(gnuradio-howto PROPERTIES DEFINE_SYMBOL "gnuradio_howto_EXPORTS")

--- a/gr-utils/python/modtool/gr-newmod/swig/CMakeLists.txt
+++ b/gr-utils/python/modtool/gr-newmod/swig/CMakeLists.txt
@@ -18,6 +18,14 @@
 # Boston, MA 02110-1301, USA.
 
 ########################################################################
+# Check if there is C++ code at all
+########################################################################
+if(NOT howto_sources)
+	MESSAGE(STATUS "no C++ sources... skipping swig/")
+	return()		
+endif(NOT howto_sources)
+
+########################################################################
 # Include swig generation macros
 ########################################################################
 find_package(SWIG)


### PR DESCRIPTION
also outputs a message to let users know why (and that) this is happening. Will hopefully save people from confusion.
