### PR TITLE
uhd: Update uhd_siggen_gui to allow setting absolute power

### DIFF
--- a/gr-uhd/apps/uhd_app.py
+++ b/gr-uhd/apps/uhd_app.py
@@ -28,7 +28,13 @@ LONG_TPL = """{prefix}  Motherboard: {mb_id} ({mb_serial})
 {prefix}  Antenna: {ant}
 """
 
+# PyLint can't reliably detect C++ exports in modules, so let's disable that
+# pylint: disable=no-member
+
 class UHDApp:
+    GAIN_TYPE_GAIN = 'dB'
+    GAIN_TYPE_POWER = 'power_dbm'
+
     " Base class for simple UHD-based applications "
     def __init__(self, prefix=None, args=None):
         self.prefix = prefix
@@ -37,7 +43,7 @@ class UHDApp:
         if self.args.sync == 'auto' and len(self.args.channels) > 1:
             self.args.sync = 'pps'
         self.antenna = None
-        self.gain_range = None
+        self.gain_range = None # Can also be power range
         self.samp_rate = None
         self.has_lo_sensor = None
         self.async_msgq = None
@@ -55,6 +61,7 @@ class UHDApp:
         self.lo_export = None
         self.usrp = None
         self.lo_source_channel = None
+        self.gain_type = self.GAIN_TYPE_GAIN
 
     def vprint(self, *args):
         """
@@ -179,8 +186,20 @@ class UHDApp:
                 ))
         self.antenna = self.usrp.get_antenna(0)
         # Set receive daughterboard gain:
-        self.set_gain(args.gain)
-        self.gain_range = self.usrp.get_gain_range(0)
+        if args.power:
+            if args.gain is not None:
+                print("[ERROR] Cannot provide both --gain and --power!")
+                sys.exit(1)
+            self.gain_type = self.GAIN_TYPE_POWER
+            if not self.usrp.has_power_reference(0):
+                print("[ERROR] Device does not have power reference capabilities!")
+                sys.exit(1)
+            self.set_power_reference(args.power)
+            self.gain_range = self.usrp.get_power_range(0)
+        else:
+            self.set_gain(args.gain)
+            self.gain_range = self.usrp.get_gain_range(0)
+            self.gain_type = self.GAIN_TYPE_GAIN
         # Set frequency (tune request takes lo_offset):
         if hasattr(args, 'lo_offset') and args.lo_offset is not None:
             treq = uhd.tune_request(args.freq, args.lo_offset)
@@ -268,10 +287,19 @@ class UHDApp:
                         chan=chan, g=self.usrp.get_gain(i)
                     ))
         else:
-            self.vprint("Setting gain to {g} dB.".format(g=gain))
+            self.vprint("Setting gain to {g:.2f} dB.".format(g=gain))
             for chan in range(len(self.channels)):
                 self.usrp.set_gain(gain, chan)
         self.gain = self.usrp.get_gain(0)
+
+    def set_power_reference(self, power_dbm):
+        """
+        Safe power-ref-setter.
+        """
+        assert power_dbm is not None
+        self.vprint("Setting ref power to {g:.2f} dBm.".format(g=power_dbm))
+        self.usrp.set_power_reference(power_dbm)
+        self.gain = self.usrp.get_power_reference(0)
 
     def set_freq(self, freq, skip_sync=False):
         """
@@ -364,12 +392,11 @@ class UHDApp:
                            help="Sample rate")
         group.add_argument("-g", "--gain", type=eng_arg.eng_float, default=None,
                            help="Gain (default is midpoint)")
-        group.add_argument("--gain-type", choices=('db', 'normalized'), default='db',
-                           help="Gain Type (applies to -g)")
-        group.add_argument("-p", "--power-ref", type=eng_arg.eng_float, default=None,
-                           help="Reference power level (in dBm). "
+        group.add_argument("-p", "--power", type=eng_arg.eng_float, default=None,
+                           help="(Reference) power level (in dBm). "
                                 "Not supported by all devices (see UHD manual). "
-                                "Will fail if not supported. Precludes --gain. ")
+                                "Will fail if not supported. Precludes --gain. "
+                                "Behaviour may differ between applications.")
         if not skip_freq:
             group.add_argument("-f", "--freq", type=eng_arg.eng_float, default=None, required=True,
                                help="Set carrier frequency to FREQ",

--- a/gr-uhd/apps/uhd_fft
+++ b/gr-uhd/apps/uhd_fft
@@ -89,7 +89,6 @@ class uhd_fft(UHDApp, gr.top_block, Qt.QWidget):
         self.fft_size = args.fft_size
         self.freq = args.freq
         self.gain = args.gain
-        self.gain_type = args.gain_type
         self.samp_rate = args.samp_rate
         self.spec = args.spec
         self.stream_args = args.stream_args

--- a/gr-uhd/apps/uhd_siggen_base.py
+++ b/gr-uhd/apps/uhd_siggen_base.py
@@ -22,6 +22,9 @@ from gnuradio import analog
 from gnuradio import blocks
 from gnuradio.gr.pubsub import pubsub
 
+# PyLint can't reliably detect C++ exports in modules, so let's disable that
+# pylint: disable=no-member
+
 DESC_KEY = 'desc'
 SAMP_RATE_KEY = 'samp_rate'
 LINK_RATE_KEY = 'link_rate'
@@ -35,7 +38,6 @@ WAVEFORM_FREQ_KEY = 'waveform_freq'
 WAVEFORM_OFFSET_KEY = 'waveform_offset'
 WAVEFORM2_FREQ_KEY = 'waveform2_freq'
 FREQ_RANGE_KEY = 'freq_range'
-GAIN_RANGE_KEY = 'gain_range'
 TYPE_KEY = 'type'
 
 WAVEFORMS = {
@@ -55,6 +57,12 @@ class USRPSiggen(gr.top_block, pubsub, UHDApp):
     def __init__(self, args):
         gr.top_block.__init__(self)
         pubsub.__init__(self)
+        # If the power argument is given, we need to turn that into a power
+        # *reference* level. This is a bit of a hack because we're assuming
+        # knowledge of UHDApp (i.e. we're leaking abstractions). But it's simple
+        # and harmless enough.
+        if args.power:
+            args.power -= 20 * math.log10(args.amplitude)
         UHDApp.__init__(self, args=args, prefix="UHD-SIGGEN")
         self.extra_sink = None
 
@@ -78,8 +86,7 @@ class USRPSiggen(gr.top_block, pubsub, UHDApp):
         self.publish(SAMP_RATE_KEY, lambda: self.usrp.get_samp_rate())
         self.publish(DESC_KEY, lambda: self.usrp_description)
         self.publish(FREQ_RANGE_KEY, lambda: self.usrp.get_freq_range(self.channels[0]))
-        self.publish(GAIN_RANGE_KEY, lambda: self.usrp.get_gain_range(self.channels[0]))
-        self.publish(GAIN_KEY, lambda: self.usrp.get_gain(self.channels[0]))
+        self.publish(GAIN_KEY, lambda: self.get_gain_or_power())
 
         self[SAMP_RATE_KEY] = args.samp_rate
         self[TX_FREQ_KEY] = args.freq
@@ -92,12 +99,13 @@ class USRPSiggen(gr.top_block, pubsub, UHDApp):
 
         #subscribe set methods
         self.subscribe(SAMP_RATE_KEY, self.set_samp_rate)
-        self.subscribe(GAIN_KEY, self.set_gain)
+        self.subscribe(GAIN_KEY, self.set_gain_or_power)
         self.subscribe(TX_FREQ_KEY, self.set_freq)
         self.subscribe(AMPLITUDE_KEY, self.set_amplitude)
         self.subscribe(WAVEFORM_FREQ_KEY, self.set_waveform_freq)
         self.subscribe(WAVEFORM2_FREQ_KEY, self.set_waveform2_freq)
         self.subscribe(TYPE_KEY, self.set_waveform)
+        self.subscribe(RF_FREQ_KEY, self.update_gain_range)
 
         #force update on pubsub keys
         for key in (SAMP_RATE_KEY, GAIN_KEY, TX_FREQ_KEY,
@@ -234,7 +242,47 @@ class USRPSiggen(gr.top_block, pubsub, UHDApp):
         else:
             return True # Waveform not yet set
         self.vprint("Set amplitude to:", amplitude)
+        self.update_gain_range()
         return True
+
+    def get_gain_or_power(self):
+        """
+        Depending on gain type, return either a power level or the current gain
+        """
+        if self.gain_type == self.GAIN_TYPE_GAIN:
+            return self.usrp.get_gain(self.channels[0])
+        # else:
+        return self.usrp.get_power_reference(self.channels[0]) \
+                    + 20 * math.log10(self[AMPLITUDE_KEY])
+
+    def set_gain_or_power(self, gain_or_power):
+        """
+        Call this if a gain or power value changed, but you're not sure which it
+        is.
+
+        If it's a power, we subtract the signal offset to generate a reference
+        power.
+        """
+        if self.gain_type == self.GAIN_TYPE_POWER:
+            self.set_power_reference(
+                gain_or_power - 20 * math.log10(self[AMPLITUDE_KEY]))
+        else:
+            self.set_gain(gain_or_power)
+
+    def update_gain_range(self):
+        """
+        Update self.gain_range.
+        """
+        if self.gain_type == self.GAIN_TYPE_POWER:
+            power_range = self.usrp.get_power_range(self.channels[0])
+            ampl_offset = 20 * math.log10(self[AMPLITUDE_KEY])
+            self.gain_range = uhd.meta_range(
+                math.floor(power_range.start() + ampl_offset),
+                math.ceil(power_range.stop() + ampl_offset),
+                power_range.step()
+            )
+            self.vprint("Updated power range to {:.2f} ... {:.2f} dBm.".format(
+                self.gain_range.start(), self.gain_range.stop()))
 
 
 def setup_argparser():

--- a/gr-uhd/apps/uhd_siggen_gui
+++ b/gr-uhd/apps/uhd_siggen_gui
@@ -23,6 +23,7 @@ Signal Generator App
 import sys
 import threading
 import time
+import math
 from PyQt5 import Qt
 from PyQt5.QtCore import pyqtSlot
 import sip # Needs to be imported after PyQt5, could fail otherwise
@@ -190,7 +191,8 @@ class uhd_siggen_gui(Qt.QWidget):
         self._freq2_offset_win.setEnabled(self._sg[uhd_siggen.TYPE_KEY] in self._freq2_enable_on)
         self.top_grid_layout.addWidget(self._freq2_offset_win, 4, 3, 1, 2)
         ### Amplitude
-        self._amplitude_range = Range(0, 1, .001, .7, 200)
+        self._amplitude_range = \
+            Range(0, 1, .001, self._sg[uhd_siggen.AMPLITUDE_KEY], 200)
         self._amplitude_win = RangeWidget(
             self._amplitude_range,
             self.set_amplitude,
@@ -199,18 +201,22 @@ class uhd_siggen_gui(Qt.QWidget):
             float
         )
         self.top_grid_layout.addWidget(self._amplitude_win, 5, 0, 1, 5)
-        ### Gain
+        ### Gain or power
         self._gain_range = Range(
-            self.usrp.get_gain_range(self._sg.channels[0]).start(),
-            self.usrp.get_gain_range(self._sg.channels[0]).stop(),
+            math.floor(self._sg.gain_range.start()),
+            math.ceil(self._sg.gain_range.stop()),
             .5,
-            self.usrp.get_gain(self._sg.channels[0]),
+            self._sg.get_gain_or_power(),
             200.,
         )
         self._gain_win = RangeWidget(
             self._gain_range,
-            self._sg.set_gain,
-            "TX Gain", "counter_slider", float
+            self.set_gain_or_power,
+            "TX Gain (dB)"
+            if self._sg.gain_type == self._sg.GAIN_TYPE_GAIN
+            else "TX Power (dBm)",
+            "counter_slider",
+            float
         )
         self.top_grid_layout.addWidget(self._gain_win, 6, 0, 1, 5)
         ### Samp rate, LO sync, Antenna Select
@@ -375,6 +381,8 @@ class uhd_siggen_gui(Qt.QWidget):
             if idx == 0:
                 self.set_label_dsp_freq(tune_res.actual_dsp_freq)
                 self.set_label_rf_freq(tune_res.actual_rf_freq)
+        if self._sg.gain_type == self._sg.GAIN_TYPE_POWER:
+            self._sg[uhd_siggen.RF_FREQ_KEY] = self._sg[uhd_siggen.RF_FREQ_KEY]
 
     def set_freq1_offset(self, freq1_offset):
         """ Execute when the freq1 slider is moved """
@@ -386,7 +394,20 @@ class uhd_siggen_gui(Qt.QWidget):
 
     def set_amplitude(self, amplitude):
         """ Execute when the amplitude slider is moved """
+        # Here's a catch-22: The current power is calculated using the amplitude
+        # so we need to stash it before the amplitude changes, then reapply
+        # later.
+        power = self._sg[uhd_siggen.GAIN_KEY]
         self._sg[uhd_siggen.AMPLITUDE_KEY] = amplitude
+        if self._sg.gain_type == self._sg.GAIN_TYPE_POWER:
+            self._sg[uhd_siggen.GAIN_KEY] = power
+
+    def set_gain_or_power(self, gain_or_power):
+        """
+        Execute when the gain/power slider is moved
+        """
+        self._sg.set_gain_or_power(gain_or_power)
+        self._gain_win.d_widget.setValue(self._sg.get_gain_or_power())
 
     def set_sync_phases(self, sync):
         """ Execute when the sync-phases button is pushed """

--- a/gr-uhd/docs/uhd.dox
+++ b/gr-uhd/docs/uhd.dox
@@ -88,6 +88,7 @@ Command name | Value Type   | Description
 -------------|--------------|-------------------------------------------------------------
 `chan`       | int          | Specifies a channel. If this is not given, either all channels are chosen, or channel 0, depending on the action. A value of -1 forces 'all channels', where possible.
 `gain`       | double       | Sets the Tx or Rx gain (in dB). Defaults to all channels.
+`power_dbm`  | double       | Sets the Tx or Rx power reference level (in dBm). Defaults to all channels. Works for certain devices only, and only if calibration data is available.
 `freq`       | double       | Sets the Tx or Rx frequency. Defaults to all channels. If specified without `lo_offset`, it will set the LO offset to zero.
 `lo_offset`  | double       | Sets an LO offset. Defaults to all channels. Note this does not affect the effective center frequency.
 `tune`       | tune_request | Like freq, but sets a full tune request (i.e. center frequency and DSP offset). Defaults to all channels.

--- a/gr-uhd/include/gnuradio/uhd/usrp_block.h
+++ b/gr-uhd/include/gnuradio/uhd/usrp_block.h
@@ -20,6 +20,7 @@ namespace uhd {
 
 GR_UHD_API const pmt::pmt_t cmd_chan_key();
 GR_UHD_API const pmt::pmt_t cmd_gain_key();
+GR_UHD_API const pmt::pmt_t cmd_power_key();
 GR_UHD_API const pmt::pmt_t cmd_freq_key();
 GR_UHD_API const pmt::pmt_t cmd_lo_offset_key();
 GR_UHD_API const pmt::pmt_t cmd_tune_key();
@@ -228,6 +229,65 @@ public:
      */
     virtual ::uhd::gain_range_t get_gain_range(const std::string& name,
                                                size_t chan = 0) = 0;
+
+    /*! Query if this device is capable of absolute power levels
+     *
+     * If true, the set_power_reference() and get_power_reference() APIs can be
+     * used as well.
+     * Note that if the underlying UHD version doesn't support power APIs, a
+     * warning will be printed, and the return value is always false.
+     *
+     * \param chan the channel index 0 to N-1
+     * \returns true if there is a power reference API available for this channel
+     */
+    virtual bool has_power_reference(size_t chan = 0) = 0;
+
+    /*! Set the absolute power reference level for this channel
+     *
+     * Note that this API is available for certain devices only, and only if
+     * calibration data is available. Refer to the UHD manual for greater
+     * detail: https://files.ettus.com/manual/page_power.html
+     *
+     * In a nutshell, using the power reference will configure the device such
+     * that a full-scale signal (0 dBFS) corresponds to a signal at the
+     * antenna connector of \p power_dbm.
+     * After calling this function, the device will attempt to keep the power
+     * level constant after retuning, which means the gain level may be changed
+     * after a re-tune.
+     *
+     * The device may coerce the available power level (for example, if the
+     * requested power level is not achievable by the device). The coerced
+     * value may be read by calling get_power_reference().
+     *
+     * \param power_dbm The power reference level in dBm
+     * \param chan the channel index 0 to N-1
+     * \throws std::runtime_error if the underlying UHD version does not support
+     *         the power API.
+     */
+    virtual void set_power_reference(double power_dbm, size_t chan = 0) = 0;
+
+    /*! Return the absolute power reference level for this channel
+     *
+     * Note that this API is only available for certain devices, and assuming
+     * the existence of calibration data. Refer to the UHD manual for greater
+     * detail: https://files.ettus.com/manual/page_compat.html
+     *
+     * See also set_power_reference().
+     *
+     * \param chan the channel index 0 to N-1
+     * \throws std::runtime_error if the underlying UHD version does not support
+     *         the power API.
+     */
+    virtual double get_power_reference(size_t chan = 0) = 0;
+
+    /*! Return the available power range
+     *
+     * \param chan the channel index 0 to N-1
+     * \return the power range in dBm
+     * \throws std::runtime_error if the underlying UHD version does not support
+     *         the power API.
+     */
+    virtual ::uhd::meta_range_t get_power_range(size_t chan = 0) = 0;
 
     /*!
      * Set the antenna to use for a given channel.

--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -36,6 +36,11 @@ const pmt::pmt_t gr::uhd::cmd_gain_key()
     static const pmt::pmt_t val = pmt::mp("gain");
     return val;
 }
+const pmt::pmt_t gr::uhd::cmd_power_key()
+{
+    static const pmt::pmt_t val = pmt::mp("power_dbm");
+    return val;
+}
 const pmt::pmt_t gr::uhd::cmd_freq_key()
 {
     static const pmt::pmt_t val = pmt::mp("freq");
@@ -134,6 +139,7 @@ usrp_block_impl::usrp_block_impl(const ::uhd::device_addr_t& device_addr,
     // Register default command handlers:
     REGISTER_CMD_HANDLER(cmd_freq_key(), _cmd_handler_freq);
     REGISTER_CMD_HANDLER(cmd_gain_key(), _cmd_handler_gain);
+    REGISTER_CMD_HANDLER(cmd_power_key(), _cmd_handler_power);
     REGISTER_CMD_HANDLER(cmd_lo_offset_key(), _cmd_handler_looffset);
     REGISTER_CMD_HANDLER(cmd_tune_key(), _cmd_handler_tune);
     REGISTER_CMD_HANDLER(cmd_lo_freq_key(), _cmd_handler_lofreq);
@@ -647,6 +653,21 @@ void usrp_block_impl::_cmd_handler_gain(const pmt::pmt_t& gain_,
     }
 
     set_gain(gain, chan);
+}
+
+void usrp_block_impl::_cmd_handler_power(const pmt::pmt_t& power_dbm_,
+                                         int chan,
+                                         const pmt::pmt_t& msg)
+{
+    double power_dbm = pmt::to_double(power_dbm_);
+    if (chan == -1) {
+        for (size_t i = 0; i < _nchan; i++) {
+            set_power_reference(power_dbm, i);
+        }
+        return;
+    }
+
+    set_power_reference(power_dbm, chan);
 }
 
 void usrp_block_impl::_cmd_handler_antenna(const pmt::pmt_t& ant,

--- a/gr-uhd/lib/usrp_block_impl.h
+++ b/gr-uhd/lib/usrp_block_impl.h
@@ -118,6 +118,7 @@ protected:
     void
     _cmd_handler_looffset(const pmt::pmt_t& lo_offset, int chan, const pmt::pmt_t& msg);
     void _cmd_handler_gain(const pmt::pmt_t& gain, int chan, const pmt::pmt_t& msg);
+    void _cmd_handler_power(const pmt::pmt_t& power_dbm, int chan, const pmt::pmt_t& msg);
     void _cmd_handler_antenna(const pmt::pmt_t& ant, int chan, const pmt::pmt_t& msg);
     void _cmd_handler_rate(const pmt::pmt_t& rate, int chan, const pmt::pmt_t& msg);
     void _cmd_handler_tune(const pmt::pmt_t& tune, int chan, const pmt::pmt_t& msg);

--- a/gr-uhd/lib/usrp_sink_impl.cc
+++ b/gr-uhd/lib/usrp_sink_impl.cc
@@ -187,6 +187,66 @@ std::vector<std::string> usrp_sink_impl::get_gain_names(size_t chan)
     return _dev->get_tx_gain_range(name, chan);
 }
 
+bool usrp_sink_impl::has_power_reference(size_t chan)
+{
+#ifdef UHD_USRP_MULTI_USRP_POWER_LEVEL
+    if (chan >= _stream_args.channels.size()) {
+        throw std::out_of_range("Invalid channel: " + std::to_string(chan));
+    }
+    const size_t dev_chan = _stream_args.channels[chan];
+    return _dev->has_tx_power_reference(dev_chan);
+#else
+    GR_LOG_WARN(d_logger,
+                "UHD version 4.0 or greater required for power reference API. ");
+    return false;
+#endif
+}
+
+void usrp_sink_impl::set_power_reference(double power_dbm, size_t chan)
+{
+#ifdef UHD_USRP_MULTI_USRP_POWER_LEVEL
+    if (chan >= _stream_args.channels.size()) {
+        throw std::out_of_range("Invalid channel: " + std::to_string(chan));
+    }
+    const size_t dev_chan = _stream_args.channels[chan];
+    _dev->set_tx_power_reference(power_dbm, dev_chan);
+#else
+    GR_LOG_ERROR(d_logger,
+                 "UHD version 4.0 or greater required for power reference API.");
+    throw std::runtime_error("not implemented in this version");
+#endif
+}
+
+double usrp_sink_impl::get_power_reference(size_t chan)
+{
+#ifdef UHD_USRP_MULTI_USRP_POWER_LEVEL
+    if (chan >= _stream_args.channels.size()) {
+        throw std::out_of_range("Invalid channel: " + std::to_string(chan));
+    }
+    const size_t dev_chan = _stream_args.channels[chan];
+    return _dev->get_tx_power_reference(dev_chan);
+#else
+    GR_LOG_ERROR(d_logger,
+                 "UHD version 4.0 or greater required for power reference API.");
+    throw std::runtime_error("not implemented in this version");
+#endif
+}
+
+::uhd::meta_range_t usrp_sink_impl::get_power_range(size_t chan)
+{
+#ifdef UHD_USRP_MULTI_USRP_POWER_LEVEL
+    if (chan >= _stream_args.channels.size()) {
+        throw std::out_of_range("Invalid channel: " + std::to_string(chan));
+    }
+    const size_t dev_chan = _stream_args.channels[chan];
+    return _dev->get_tx_power_range(dev_chan);
+#else
+    GR_LOG_ERROR(d_logger,
+                 "UHD version 4.0 or greater required for power reference API.");
+    throw std::runtime_error("not implemented in this version");
+#endif
+}
+
 void usrp_sink_impl::set_antenna(const std::string& ant, size_t chan)
 {
     chan = _stream_args.channels[chan];

--- a/gr-uhd/lib/usrp_sink_impl.h
+++ b/gr-uhd/lib/usrp_sink_impl.h
@@ -66,6 +66,9 @@ public:
     std::vector<std::string> get_gain_names(size_t chan);
     ::uhd::gain_range_t get_gain_range(size_t chan);
     ::uhd::gain_range_t get_gain_range(const std::string& name, size_t chan);
+    bool has_power_reference(size_t chan);
+    double get_power_reference(size_t chan);
+    ::uhd::meta_range_t get_power_range(size_t chan);
     std::string get_antenna(size_t chan);
     std::vector<std::string> get_antennas(size_t chan);
     ::uhd::sensor_value_t get_sensor(const std::string& name, size_t chan);
@@ -86,6 +89,7 @@ public:
     void set_gain(double gain, size_t chan);
     void set_gain(double gain, const std::string& name, size_t chan);
     void set_normalized_gain(double gain, size_t chan);
+    void set_power_reference(double power_dbm, size_t chan);
     void set_antenna(const std::string& ant, size_t chan);
     void set_bandwidth(double bandwidth, size_t chan);
     double get_bandwidth(size_t chan);

--- a/gr-uhd/lib/usrp_source_impl.cc
+++ b/gr-uhd/lib/usrp_source_impl.cc
@@ -203,6 +203,65 @@ std::vector<std::string> usrp_source_impl::get_gain_names(size_t chan)
     return _dev->get_rx_gain_range(name, chan);
 }
 
+bool usrp_source_impl::has_power_reference(size_t chan)
+{
+#ifdef UHD_USRP_MULTI_USRP_POWER_LEVEL
+    if (chan >= _stream_args.channels.size()) {
+        throw std::out_of_range("Invalid channel: " + std::to_string(chan));
+    }
+    const size_t dev_chan = _stream_args.channels[chan];
+    return _dev->has_rx_power_reference(dev_chan);
+#else
+    GR_LOG_WARN(d_logger, "UHD version 4.0 or greater required for power reference API.");
+    return false;
+#endif
+}
+
+void usrp_source_impl::set_power_reference(double power_dbm, size_t chan)
+{
+#ifdef UHD_USRP_MULTI_USRP_POWER_LEVEL
+    if (chan >= _stream_args.channels.size()) {
+        throw std::out_of_range("Invalid channel: " + std::to_string(chan));
+    }
+    const size_t dev_chan = _stream_args.channels[chan];
+    _dev->set_rx_power_reference(power_dbm, dev_chan);
+#else
+    GR_LOG_ERROR(d_logger,
+                 "UHD version 4.0 or greater required for power reference API.");
+    throw std::runtime_error("not implemented in this version");
+#endif
+}
+
+double usrp_source_impl::get_power_reference(size_t chan)
+{
+#ifdef UHD_USRP_MULTI_USRP_POWER_LEVEL
+    if (chan >= _stream_args.channels.size()) {
+        throw std::out_of_range("Invalid channel: " + std::to_string(chan));
+    }
+    const size_t dev_chan = _stream_args.channels[chan];
+    return _dev->get_rx_power_reference(dev_chan);
+#else
+    GR_LOG_ERROR(d_logger,
+                 "UHD version 4.0 or greater required for power reference API.");
+    throw std::runtime_error("not implemented in this version");
+#endif
+}
+
+::uhd::meta_range_t usrp_source_impl::get_power_range(size_t chan)
+{
+#ifdef UHD_USRP_MULTI_USRP_POWER_LEVEL
+    if (chan >= _stream_args.channels.size()) {
+        throw std::out_of_range("Invalid channel: " + std::to_string(chan));
+    }
+    const size_t dev_chan = _stream_args.channels[chan];
+    return _dev->get_rx_power_range(dev_chan);
+#else
+    GR_LOG_ERROR(d_logger,
+                 "UHD version 4.0 or greater required for power reference API.");
+    throw std::runtime_error("not implemented in this version");
+#endif
+}
+
 void usrp_source_impl::set_antenna(const std::string& ant, size_t chan)
 {
     chan = _stream_args.channels[chan];

--- a/gr-uhd/lib/usrp_source_impl.h
+++ b/gr-uhd/lib/usrp_source_impl.h
@@ -51,6 +51,9 @@ public:
     std::vector<std::string> get_gain_names(size_t chan);
     ::uhd::gain_range_t get_gain_range(size_t chan);
     ::uhd::gain_range_t get_gain_range(const std::string& name, size_t chan);
+    bool has_power_reference(size_t chan);
+    double get_power_reference(size_t chan);
+    ::uhd::meta_range_t get_power_range(size_t chan);
     std::string get_antenna(size_t chan);
     std::vector<std::string> get_antennas(size_t chan);
     ::uhd::sensor_value_t get_sensor(const std::string& name, size_t chan);
@@ -72,6 +75,7 @@ public:
     void set_gain(double gain, const std::string& name, size_t chan);
     void set_rx_agc(const bool enable, size_t chan);
     void set_normalized_gain(double gain, size_t chan);
+    void set_power_reference(double power_dbm, size_t chan);
     void set_antenna(const std::string& ant, size_t chan);
     void set_bandwidth(double bandwidth, size_t chan);
     double get_bandwidth(size_t chan);

--- a/gr-uhd/python/uhd/bindings/docstrings/usrp_block_pydoc_template.h
+++ b/gr-uhd/python/uhd/bindings/docstrings/usrp_block_pydoc_template.h
@@ -75,6 +75,18 @@ static const char* __doc_gr_uhd_usrp_block_get_gain_range_0 = R"doc()doc";
 static const char* __doc_gr_uhd_usrp_block_get_gain_range_1 = R"doc()doc";
 
 
+static const char* __doc_gr_uhd_usrp_block_has_power_reference = R"doc()doc";
+
+
+static const char* __doc_gr_uhd_usrp_block_set_power_reference = R"doc()doc";
+
+
+static const char* __doc_gr_uhd_usrp_block_get_power_reference = R"doc()doc";
+
+
+static const char* __doc_gr_uhd_usrp_block_get_power_range = R"doc()doc";
+
+
 static const char* __doc_gr_uhd_usrp_block_set_antenna = R"doc()doc";
 
 

--- a/gr-uhd/python/uhd/bindings/usrp_block_python.cc
+++ b/gr-uhd/python/uhd/bindings/usrp_block_python.cc
@@ -151,6 +151,31 @@ void bind_usrp_block(py::module& m)
              D(usrp_block, get_gain_range, 1))
 
 
+        .def("has_power_reference",
+             &usrp_block::has_power_reference,
+             py::arg("chan") = 0,
+             D(usrp_block, has_power_reference))
+
+
+        .def("set_power_reference",
+             &usrp_block::set_power_reference,
+             py::arg("power_dbm"),
+             py::arg("chan") = 0,
+             D(usrp_block, set_power_reference))
+
+
+        .def("get_power_reference",
+             &usrp_block::get_power_reference,
+             py::arg("chan") = 0,
+             D(usrp_block, get_power_reference))
+
+
+        .def("get_power_range",
+             &usrp_block::get_power_range,
+             py::arg("chan") = 0,
+             D(usrp_block, get_power_range))
+
+
         .def("set_antenna",
              &usrp_block::set_antenna,
              py::arg("ant"),


### PR DESCRIPTION
Note: This requires a USRP with power API enabled.

Summary of changes:
- uhd_app now provides the --power argument and applies it as
  a reference power level. It clashes with --gain. UHDApp now has two
  'modes' for setting the power: Via gain (the previous, standard way)
  or by setting a power. UHDApp calls all the right APIs for each use
  case.
- uhd_siggen_base is now aware of these settings and will make sure the
  output power is correct by combining the requested power and the
  requested amplitude (meaning, it sets a ref power that is at the
  correct level above the requested power level).
- The GUI can now set either power or gain, depending on command line
  arguments. When changing the amplitude in power mode, the ref power is
  also changed so the output power (in dBm) stays the same when the
  amplitude changes.