### PR TITLE
uhd: uhd_fft: Add support for --power argument

### DIFF
--- a/gr-uhd/apps/uhd_fft
+++ b/gr-uhd/apps/uhd_fft
@@ -30,6 +30,7 @@ import ctypes
 import sys
 import threading
 import time
+import math
 from PyQt5 import Qt
 import sip # Needs to be imported after PyQt5, could fail otherwise
 from gnuradio import eng_notation
@@ -139,17 +140,29 @@ class uhd_fft(UHDApp, gr.top_block, Qt.QWidget):
             lambda: self.set_samp_rate(eng_notation.str_to_num(
                 str(self._samp_rate__line_edit.text()))))
         self.top_grid_layout.addWidget(self._samp_rate__tool_bar, 3, 2, 1, 2)
-        # Gain:
-        self._gain__range = Range(
-            self.gain_range.start(),
-            self.gain_range.stop(),
+        # Gain or Power:
+        self._gain_range = Range(
+            math.floor(self.gain_range.start()),
+            math.ceil(self.gain_range.stop()),
             max(self.gain_range.step(), 1.0),
-            self.gain,
-            200
+            self.gain if self.gain_type == self.GAIN_TYPE_GAIN
+            else self.get_gain_or_power(),
+            200.,
         )
         self._gain__win = RangeWidget(
-            self._gain__range, self.set_gain, "RX Gain", "counter_slider", float)
+            self._gain_range,
+            self.set_gain_or_power,
+            "RX Gain (dB)" if self.gain_type == self.GAIN_TYPE_GAIN
+            else "RX Power Reference (dBm)",
+            "counter_slider",
+            float
+        )
         self.top_grid_layout.addWidget(self._gain__win, 2, 0, 1, 4)
+        if self.gain_type == self.GAIN_TYPE_POWER:
+            self.power_scalers = [
+                blocks.multiply_const_cc(self.get_power_scaler())
+                for _ in range(len(self.channels))
+            ]
         # Center frequency:
         self._freq_tool_bar = Qt.QToolBar(self)
         self._freq_tool_bar.addWidget(Qt.QLabel("RX Tune Frequency: "))
@@ -276,12 +289,19 @@ class uhd_fft(UHDApp, gr.top_block, Qt.QWidget):
         )
         self.qtgui_freq_sink_x_0.set_update_time(self.update_rate)
         self.qtgui_freq_sink_x_0.set_y_axis(-100, 10)
+        if self.gain_type == self.GAIN_TYPE_GAIN:
+            self.qtgui_freq_sink_x_0.set_y_label("Relative Gain", "dB")
+        else:
+            self.qtgui_freq_sink_x_0.set_y_label("Received Power", "dBm")
         self.qtgui_freq_sink_x_0.set_trigger_mode(qtgui.TRIG_MODE_FREE, 0.0, 0, "")
         self.qtgui_freq_sink_x_0.enable_autoscale(True)
         self.qtgui_freq_sink_x_0.enable_grid(True)
         self.qtgui_freq_sink_x_0.set_fft_average(self.fft_average)
         self.qtgui_freq_sink_x_0.enable_control_panel(True)
         self.qtgui_freq_sink_x_0.disable_legend()
+        # Normalize windows so we can switch between windows live without losing
+        # power to the window itself
+        self.qtgui_freq_sink_x_0.set_fft_window_normalized(True)
         for i in range(len(self.channels)):
             self.qtgui_freq_sink_x_0.set_line_label(i, "Channel {0}".format(i))
             self.qtgui_freq_sink_x_0.set_line_width(i, widths[i])
@@ -397,7 +417,15 @@ class uhd_fft(UHDApp, gr.top_block, Qt.QWidget):
             (self.qtgui_waterfall_sink_x_0, 'freq'),
             (self.usrp, 'command'))
         for idx in range(len(self.channels)):
-            self.connect((self.usrp, idx), (self.qtgui_freq_sink_x_0, idx))
+            if self.gain_type == self.GAIN_TYPE_POWER:
+                # If we're in power mode, we have to scale the signal before it
+                # goes into the FFT block such that the power levels match
+                self.connect(
+                    (self.usrp, idx),
+                    self.power_scalers[idx],
+                    (self.qtgui_freq_sink_x_0, idx))
+            else:
+                self.connect((self.usrp, idx), (self.qtgui_freq_sink_x_0, idx))
             self.connect((self.usrp, idx), (self.qtgui_time_sink_x_0, idx))
             self.connect((self.usrp, idx), (self.qtgui_waterfall_sink_x_0, idx))
         if args.phase_relations and len(self.channels) > 1:
@@ -477,6 +505,28 @@ class uhd_fft(UHDApp, gr.top_block, Qt.QWidget):
         self._ant_callback(self.antenna)
         for c in range(len(self.channels)):
             self.usrp.set_antenna(self.antenna, c)
+
+    def set_gain_or_power(self, gain_or_power):
+        """ Execute when gain/power input has changed """
+        if self.gain_type == self.GAIN_TYPE_GAIN:
+            self.set_gain(gain_or_power)
+        else:
+            self.set_power_reference(gain_or_power)
+            for scaler in self.power_scalers:
+                scaler.set_k(self.get_power_scaler())
+
+    def get_gain_or_power(self):
+        """ Read back either gain or ref power based on mode """
+        if self.gain_type == self.GAIN_TYPE_GAIN:
+            return self.usrp.get_gain(0)
+        return self.usrp.get_power_reference(0)
+
+    def get_power_scaler(self):
+        """
+        Return the input to the power scaler as a function of the current power
+        reference level.
+        """
+        return 10**(self.gain/20)
 
 
 def setup_argparser():

--- a/gr-uhd/docs/uhd.dox
+++ b/gr-uhd/docs/uhd.dox
@@ -88,6 +88,7 @@ Command name | Value Type   | Description
 -------------|--------------|-------------------------------------------------------------
 `chan`       | int          | Specifies a channel. If this is not given, either all channels are chosen, or channel 0, depending on the action. A value of -1 forces 'all channels', where possible.
 `gain`       | double       | Sets the Tx or Rx gain (in dB). Defaults to all channels.
+`power_dbm`  | double       | Sets the Tx or Rx power reference level (in dBm). Defaults to all channels. Only works for certain devices, if calibration data is available.
 `freq`       | double       | Sets the Tx or Rx frequency. Defaults to all channels. If specified without `lo_offset`, it will set the LO offset to zero.
 `lo_offset`  | double       | Sets an LO offset. Defaults to all channels. Note this does not affect the effective center frequency.
 `tune`       | tune_request | Like freq, but sets a full tune request (i.e. center frequency and DSP offset). Defaults to all channels.

--- a/gr-uhd/include/gnuradio/uhd/usrp_block.h
+++ b/gr-uhd/include/gnuradio/uhd/usrp_block.h
@@ -20,6 +20,7 @@ namespace uhd {
 
 GR_UHD_API const pmt::pmt_t cmd_chan_key();
 GR_UHD_API const pmt::pmt_t cmd_gain_key();
+GR_UHD_API const pmt::pmt_t cmd_power_key();
 GR_UHD_API const pmt::pmt_t cmd_freq_key();
 GR_UHD_API const pmt::pmt_t cmd_lo_offset_key();
 GR_UHD_API const pmt::pmt_t cmd_tune_key();
@@ -228,6 +229,56 @@ public:
      */
     virtual ::uhd::gain_range_t get_gain_range(const std::string& name,
                                                size_t chan = 0) = 0;
+
+    /*! Query if this device is capable of absolute power levels
+     *
+     * If true, the set_power_reference() and get_power_reference() APIs can be
+     * used as well.
+     *
+     * \param chan the channel index 0 to N-1
+     * \returns true if there is a power reference API available for this channel
+     */
+    virtual bool has_power_reference(const size_t chan = 0) = 0;
+
+    /*! Set the absolute power reference level for this channel
+     *
+     * Note that this API is only available for certain devices, and assuming
+     * the existence of calibration data. Refer to the UHD manual for greater
+     * detail: https://files.ettus.com/manual/page_compat.html
+     *
+     * In a nutshell, this will configure the device that a full-scale signal
+     * (0 dBFS) corresponds to a signal at the antenna connector of \p power_dbm.
+     * After calling this function, the device will attempt to keep the power
+     * level constant after retuning, which means the gain level may be changed
+     * after a re-tune.
+     *
+     * The device may coerce the available power level (for example, if the
+     * requested power level is not achievable by the device). The coerced
+     * value may be read by calling get_power_reference().
+     *
+     * \param power_dbm The power reference level in dBm
+     * \param chan the channel index 0 to N-1
+     */
+    virtual void set_power_reference(const double power_dbm, const size_t chan = 0) = 0;
+
+    /*! Return the absolute power reference level for this channel
+     *
+     * Note that this API is only available for certain devices, and assuming
+     * the existence of calibration data. Refer to the UHD manual for greater
+     * detail: https://files.ettus.com/manual/page_compat.html
+     *
+     * See also set_power_reference().
+     *
+     * \param chan the channel index 0 to N-1
+     */
+    virtual double get_power_reference(const size_t chan = 0) = 0;
+
+    /*! Return the available power range
+     *
+     * \param chan the channel index 0 to N-1
+     * \return the power range in dBm
+     */
+    virtual ::uhd::meta_range_t get_power_range(size_t chan = 0) = 0;
 
     /*!
      * Set the antenna to use for a given channel.

--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -36,6 +36,11 @@ const pmt::pmt_t gr::uhd::cmd_gain_key()
     static const pmt::pmt_t val = pmt::mp("gain");
     return val;
 }
+const pmt::pmt_t gr::uhd::cmd_power_key()
+{
+    static const pmt::pmt_t val = pmt::mp("power_dbm");
+    return val;
+}
 const pmt::pmt_t gr::uhd::cmd_freq_key()
 {
     static const pmt::pmt_t val = pmt::mp("freq");
@@ -134,6 +139,7 @@ usrp_block_impl::usrp_block_impl(const ::uhd::device_addr_t& device_addr,
     // Register default command handlers:
     REGISTER_CMD_HANDLER(cmd_freq_key(), _cmd_handler_freq);
     REGISTER_CMD_HANDLER(cmd_gain_key(), _cmd_handler_gain);
+    REGISTER_CMD_HANDLER(cmd_power_key(), _cmd_handler_power);
     REGISTER_CMD_HANDLER(cmd_lo_offset_key(), _cmd_handler_looffset);
     REGISTER_CMD_HANDLER(cmd_tune_key(), _cmd_handler_tune);
     REGISTER_CMD_HANDLER(cmd_lo_freq_key(), _cmd_handler_lofreq);
@@ -647,6 +653,21 @@ void usrp_block_impl::_cmd_handler_gain(const pmt::pmt_t& gain_,
     }
 
     set_gain(gain, chan);
+}
+
+void usrp_block_impl::_cmd_handler_power(const pmt::pmt_t& power_dbm_,
+                                         int chan,
+                                         const pmt::pmt_t& msg)
+{
+    double power_dbm = pmt::to_double(power_dbm_);
+    if (chan == -1) {
+        for (size_t i = 0; i < _nchan; i++) {
+            set_power_reference(power_dbm, i);
+        }
+        return;
+    }
+
+    set_power_reference(power_dbm, chan);
 }
 
 void usrp_block_impl::_cmd_handler_antenna(const pmt::pmt_t& ant,

--- a/gr-uhd/lib/usrp_block_impl.h
+++ b/gr-uhd/lib/usrp_block_impl.h
@@ -118,6 +118,7 @@ protected:
     void
     _cmd_handler_looffset(const pmt::pmt_t& lo_offset, int chan, const pmt::pmt_t& msg);
     void _cmd_handler_gain(const pmt::pmt_t& gain, int chan, const pmt::pmt_t& msg);
+    void _cmd_handler_power(const pmt::pmt_t& power_dbm, int chan, const pmt::pmt_t& msg);
     void _cmd_handler_antenna(const pmt::pmt_t& ant, int chan, const pmt::pmt_t& msg);
     void _cmd_handler_rate(const pmt::pmt_t& rate, int chan, const pmt::pmt_t& msg);
     void _cmd_handler_tune(const pmt::pmt_t& tune, int chan, const pmt::pmt_t& msg);

--- a/gr-uhd/lib/usrp_sink_impl.cc
+++ b/gr-uhd/lib/usrp_sink_impl.cc
@@ -187,6 +187,46 @@ std::vector<std::string> usrp_sink_impl::get_gain_names(size_t chan)
     return _dev->get_tx_gain_range(name, chan);
 }
 
+bool usrp_sink_impl::has_power_reference(const size_t chan)
+{
+#ifdef UHD_USRP_MULTI_USRP_POWER_LEVEL
+    const size_t dev_chan = _stream_args.channels[chan];
+    return _dev->has_tx_power_reference(dev_chan);
+#else
+    return false;
+#endif
+}
+
+void usrp_sink_impl::set_power_reference(const double power_dbm, const size_t chan)
+{
+#ifdef UHD_USRP_MULTI_USRP_POWER_LEVEL
+    const size_t dev_chan = _stream_args.channels[chan];
+    _dev->set_tx_power_reference(power_dbm, dev_chan);
+#else
+    throw std::runtime_error("not implemented in this version");
+#endif
+}
+
+double usrp_sink_impl::get_power_reference(const size_t chan)
+{
+#ifdef UHD_USRP_MULTI_USRP_POWER_LEVEL
+    const size_t dev_chan = _stream_args.channels[chan];
+    return _dev->get_tx_power_reference(dev_chan);
+#else
+    throw std::runtime_error("not implemented in this version");
+#endif
+}
+
+::uhd::meta_range_t usrp_sink_impl::get_power_range(size_t chan)
+{
+#ifdef UHD_USRP_MULTI_USRP_POWER_LEVEL
+    const size_t dev_chan = _stream_args.channels[chan];
+    return _dev->get_tx_power_range(dev_chan);
+#else
+    throw std::runtime_error("not implemented in this version");
+#endif
+}
+
 void usrp_sink_impl::set_antenna(const std::string& ant, size_t chan)
 {
     chan = _stream_args.channels[chan];

--- a/gr-uhd/lib/usrp_sink_impl.h
+++ b/gr-uhd/lib/usrp_sink_impl.h
@@ -66,6 +66,9 @@ public:
     std::vector<std::string> get_gain_names(size_t chan);
     ::uhd::gain_range_t get_gain_range(size_t chan);
     ::uhd::gain_range_t get_gain_range(const std::string& name, size_t chan);
+    bool has_power_reference(const size_t chan);
+    double get_power_reference(const size_t chan);
+    ::uhd::meta_range_t get_power_range(size_t chan);
     std::string get_antenna(size_t chan);
     std::vector<std::string> get_antennas(size_t chan);
     ::uhd::sensor_value_t get_sensor(const std::string& name, size_t chan);
@@ -86,6 +89,7 @@ public:
     void set_gain(double gain, size_t chan);
     void set_gain(double gain, const std::string& name, size_t chan);
     void set_normalized_gain(double gain, size_t chan);
+    void set_power_reference(const double power_dbm, const size_t chan);
     void set_antenna(const std::string& ant, size_t chan);
     void set_bandwidth(double bandwidth, size_t chan);
     double get_bandwidth(size_t chan);

--- a/gr-uhd/lib/usrp_source_impl.cc
+++ b/gr-uhd/lib/usrp_source_impl.cc
@@ -203,6 +203,46 @@ std::vector<std::string> usrp_source_impl::get_gain_names(size_t chan)
     return _dev->get_rx_gain_range(name, chan);
 }
 
+bool usrp_source_impl::has_power_reference(const size_t chan)
+{
+#ifdef UHD_USRP_MULTI_USRP_POWER_LEVEL
+    const size_t dev_chan = _stream_args.channels[chan];
+    return _dev->has_rx_power_reference(dev_chan);
+#else
+    return false;
+#endif
+}
+
+void usrp_source_impl::set_power_reference(const double power_dbm, const size_t chan)
+{
+#ifdef UHD_USRP_MULTI_USRP_POWER_LEVEL
+    const size_t dev_chan = _stream_args.channels[chan];
+    _dev->set_rx_power_reference(power_dbm, dev_chan);
+#else
+    throw std::runtime_error("not implemented in this version");
+#endif
+}
+
+double usrp_source_impl::get_power_reference(const size_t chan)
+{
+#ifdef UHD_USRP_MULTI_USRP_POWER_LEVEL
+    const size_t dev_chan = _stream_args.channels[chan];
+    return _dev->get_rx_power_reference(dev_chan);
+#else
+    throw std::runtime_error("not implemented in this version");
+#endif
+}
+
+::uhd::meta_range_t usrp_source_impl::get_power_range(size_t chan)
+{
+#ifdef UHD_USRP_MULTI_USRP_POWER_LEVEL
+    const size_t dev_chan = _stream_args.channels[chan];
+    return _dev->get_rx_power_range(dev_chan);
+#else
+    throw std::runtime_error("not implemented in this version");
+#endif
+}
+
 void usrp_source_impl::set_antenna(const std::string& ant, size_t chan)
 {
     chan = _stream_args.channels[chan];

--- a/gr-uhd/lib/usrp_source_impl.h
+++ b/gr-uhd/lib/usrp_source_impl.h
@@ -51,6 +51,9 @@ public:
     std::vector<std::string> get_gain_names(size_t chan);
     ::uhd::gain_range_t get_gain_range(size_t chan);
     ::uhd::gain_range_t get_gain_range(const std::string& name, size_t chan);
+    bool has_power_reference(const size_t chan);
+    double get_power_reference(const size_t chan);
+    ::uhd::meta_range_t get_power_range(size_t chan);
     std::string get_antenna(size_t chan);
     std::vector<std::string> get_antennas(size_t chan);
     ::uhd::sensor_value_t get_sensor(const std::string& name, size_t chan);
@@ -72,6 +75,7 @@ public:
     void set_gain(double gain, const std::string& name, size_t chan);
     void set_rx_agc(const bool enable, size_t chan);
     void set_normalized_gain(double gain, size_t chan);
+    void set_power_reference(const double power_dbm, const size_t chan);
     void set_antenna(const std::string& ant, size_t chan);
     void set_bandwidth(double bandwidth, size_t chan);
     double get_bandwidth(size_t chan);

--- a/gr-uhd/python/uhd/bindings/docstrings/usrp_block_pydoc_template.h
+++ b/gr-uhd/python/uhd/bindings/docstrings/usrp_block_pydoc_template.h
@@ -75,6 +75,18 @@ static const char* __doc_gr_uhd_usrp_block_get_gain_range_0 = R"doc()doc";
 static const char* __doc_gr_uhd_usrp_block_get_gain_range_1 = R"doc()doc";
 
 
+static const char* __doc_gr_uhd_usrp_block_has_power_reference = R"doc()doc";
+
+
+static const char* __doc_gr_uhd_usrp_block_set_power_reference = R"doc()doc";
+
+
+static const char* __doc_gr_uhd_usrp_block_get_power_reference = R"doc()doc";
+
+
+static const char* __doc_gr_uhd_usrp_block_get_power_range = R"doc()doc";
+
+
 static const char* __doc_gr_uhd_usrp_block_set_antenna = R"doc()doc";
 
 

--- a/gr-uhd/python/uhd/bindings/usrp_block_python.cc
+++ b/gr-uhd/python/uhd/bindings/usrp_block_python.cc
@@ -151,6 +151,31 @@ void bind_usrp_block(py::module& m)
              D(usrp_block, get_gain_range, 1))
 
 
+        .def("has_power_reference",
+            &usrp_block::has_power_reference,
+            py::arg("chan") = 0,
+            D(usrp_block, has_power_reference))
+
+
+        .def("set_power_reference",
+            &usrp_block::set_power_reference,
+            py::arg("power_dbm"),
+            py::arg("chan") = 0,
+            D(usrp_block, set_power_reference))
+
+
+        .def("get_power_reference",
+            &usrp_block::get_power_reference,
+            py::arg("chan") = 0,
+            D(usrp_block, get_power_reference))
+
+
+        .def("get_power_range",
+            &usrp_block::get_power_range,
+            py::arg("chan") = 0,
+            D(usrp_block, get_power_range))
+
+
         .def("set_antenna",
              &usrp_block::set_antenna,
              py::arg("ant"),

--- a/gr-uhd/python/uhd/bindings/usrp_block_python.cc
+++ b/gr-uhd/python/uhd/bindings/usrp_block_python.cc
@@ -152,28 +152,28 @@ void bind_usrp_block(py::module& m)
 
 
         .def("has_power_reference",
-            &usrp_block::has_power_reference,
-            py::arg("chan") = 0,
-            D(usrp_block, has_power_reference))
+             &usrp_block::has_power_reference,
+             py::arg("chan") = 0,
+             D(usrp_block, has_power_reference))
 
 
         .def("set_power_reference",
-            &usrp_block::set_power_reference,
-            py::arg("power_dbm"),
-            py::arg("chan") = 0,
-            D(usrp_block, set_power_reference))
+             &usrp_block::set_power_reference,
+             py::arg("power_dbm"),
+             py::arg("chan") = 0,
+             D(usrp_block, set_power_reference))
 
 
         .def("get_power_reference",
-            &usrp_block::get_power_reference,
-            py::arg("chan") = 0,
-            D(usrp_block, get_power_reference))
+             &usrp_block::get_power_reference,
+             py::arg("chan") = 0,
+             D(usrp_block, get_power_reference))
 
 
         .def("get_power_range",
-            &usrp_block::get_power_range,
-            py::arg("chan") = 0,
-            D(usrp_block, get_power_range))
+             &usrp_block::get_power_range,
+             py::arg("chan") = 0,
+             D(usrp_block, get_power_range))
 
 
         .def("set_antenna",


### PR DESCRIPTION
This enables absolute power suport for uhd_fft. For example:

    uhd_fft --power -20 --args [...]

will run uhd_fft with all the usual settings, but will set the gain such
that the reference power level is -20 dBm. The y-axis will be labeled
differently ("RX Power Level (dBm)") and the gain slider will be
replaced by a power reference level slider.

Reading the actual received power from the display requires some DSP
knowledge. First, the choice of window will move energy into sidelobes,
and of course, scalloping loss plays a role. By choosing a boxcar window,
and moving the signal close to the center of a bin, it is possible to
measure the power of a single tone, assuming the USRP has been
previously calibrated.

The y-axis scaling is achieved by throwing in a multiplier that moves
a full-scale signal to the corresponding power value, and using the
recently introduced features to normalize windows.